### PR TITLE
Fix division-by-zero error in get_scRNA_info

### DIFF
--- a/R/CELINA.R
+++ b/R/CELINA.R
@@ -613,6 +613,7 @@ Testing_interaction_all <- function(object, kernel_mat = NULL,
   ## Subset the cell type proportion matrix for remaining cell types
   celltype_mat <- t(object@celltype_mat[names(object@genes_list), ])
   celltype_mat <- sweep(celltype_mat, 1, rowSums(celltype_mat), "/")
+  celltype_mat[is.nan(celltype_mat)] <- 0 
   object@celltype_mat <- t(celltype_mat)
 
   ## Remove the cells from the cell types that have been filtered out for single cell resolution

--- a/R/CELINA.R
+++ b/R/CELINA.R
@@ -323,6 +323,12 @@ get_scRNA_info <- function(scRNA_count, sc_cell_type_labels, cell_type_names = N
     }
   }
   
+  filter_z <- which(colSums(scRNA_count)==0)
+  if(length(filter_z)>0){
+  sc_cell_type_labels <- sc_cell_type_labels[-filter_z]
+  scRNA_count <- scRNA_count[,-filter_z]
+    }
+  
   nUMI <- colSums(scRNA_count)
   n_cell_types <- length(cell_type_names)
   


### PR DESCRIPTION
### Problem:
The original `get_gene_mean` function encounters division by zero when some cells have zero UMI counts, resulting in NaN or Inf values.

### Fix:
1. Applied the filtering function to scRNA_count and sc_cell_type_labels to ensure data consistency.


### Impact:
This fix prevents erroneous results when calculating gene means and improves the robustness of downstream analysis.